### PR TITLE
[ENG-206] Fix segments/filtering with multiple extended fields

### DIFF
--- a/Entity/OverrideLeadListRepository.php
+++ b/Entity/OverrideLeadListRepository.php
@@ -503,12 +503,12 @@ class OverrideLeadListRepository extends LeadListRepository
             // get extendedField Filters first
             if (in_array($details['field'], array_keys($extendedFieldList))) {
                 // its an extended field, build a join expressions
-                $extendedLinkExpr = $extendedFieldList[$details['field']]['table'].'.lead_id = l.id';
+                $extendedAlias = $extendedFieldList[$details['field']]['table'].$k;
                 $q->leftJoin(
                     'l',
                     MAUTIC_TABLE_PREFIX.$extendedFieldList[$details['field']]['table'],
-                    $extendedFieldList[$details['field']]['table'],
-                    $extendedLinkExpr
+                    $extendedAlias,
+                    $extendedAlias.'.lead_id = l.id'
                 );
             }
         }
@@ -630,7 +630,7 @@ class OverrideLeadListRepository extends LeadListRepository
             } elseif ($isExtendedField) {
                 // this is an extendedField Custom Field type that needs custom table joins
                 // for simplicity, the full tablename is used as the table alias
-                $field = $tableName.'.value';
+                $field = $tableName.$k.'.value';
             }
 
             $columnType = false;
@@ -1708,7 +1708,7 @@ class OverrideLeadListRepository extends LeadListRepository
                         }
                     }
                     if ($isExtendedField) {
-                        $fieldNameColumn = $tableName.'.lead_field_id';
+                        $fieldNameColumn = $tableName.$k.'.lead_field_id';
                         $fieldNameValue  = $extendedFieldList[$details['field']]['id'];
                         switch ($func) {
                             case 'between':

--- a/Entity/OverrideLeadListRepository.php
+++ b/Entity/OverrideLeadListRepository.php
@@ -345,8 +345,8 @@ class OverrideLeadListRepository extends LeadListRepository
                     $q->resetQueryPart('groupBy');
                 }
 
-                $realQuery = $q->getSQL(); // for debug purposes only
-                $results   = $q->execute()->fetchAll();
+                // $realQuery = $q->getSQL(); // for debug purposes only
+                $results = $q->execute()->fetchAll();
 
                 foreach ($results as $r) {
                     if ($countOnly) {

--- a/Entity/OverrideLeadRepository.php
+++ b/Entity/OverrideLeadRepository.php
@@ -166,13 +166,13 @@ class OverrideLeadRepository extends LeadRepository implements CustomFieldReposi
 
         // Add joins for extended fields
         foreach ($this->extendedFieldFilters as $extendedFilter) {
-            $leadFieldModel       = $this->leadFieldModel;
-            $dataType             = $leadFieldModel->getSchemaDefinition($extendedFilter['alias'], $extendedFilter['type']);
-            $dataType             = $dataType['type'];
-            $secure               = false !== strpos($extendedFilter['object'], 'Secure') ? '_secure' : '';
-            $tableName            = 'lead_fields_leads_'.$dataType.$secure.'_xref';
-            $tableAlias           = $dataType.$secure.$extendedFilter['id'];
-            $extendedJoinExpr     = $q->expr()->andX(
+            $leadFieldModel   = $this->leadFieldModel;
+            $dataType         = $leadFieldModel->getSchemaDefinition($extendedFilter['alias'], $extendedFilter['type']);
+            $dataType         = $dataType['type'];
+            $secure           = false !== strpos($extendedFilter['object'], 'Secure') ? '_secure' : '';
+            $tableName        = 'lead_fields_leads_'.$dataType.$secure.'_xref';
+            $tableAlias       = $dataType.$secure.$extendedFilter['id'];
+            $extendedJoinExpr = $q->expr()->andX(
                 $q->expr()->eq('l.id ', $tableAlias.'.lead_id'),
                 $q->expr()->eq($tableAlias.'.lead_field_id', $extendedFilter['id'])
             );

--- a/Model/OverrideLeadModel.php
+++ b/Model/OverrideLeadModel.php
@@ -459,7 +459,6 @@ class OverrideLeadModel extends LeadModel
     }
 
     /** Add lead to company
-     *
      * @param array      $companies
      * @param array|Lead $lead
      *

--- a/Model/OverrideLeadModel.php
+++ b/Model/OverrideLeadModel.php
@@ -459,6 +459,7 @@ class OverrideLeadModel extends LeadModel
     }
 
     /** Add lead to company
+     *
      * @param array      $companies
      * @param array|Lead $lead
      *

--- a/Model/OverrideListModel.php
+++ b/Model/OverrideListModel.php
@@ -502,15 +502,14 @@ class OverrideListModel extends ListModel
             $properties         = $field->getProperties();
             $properties['type'] = $type;
             // Force extendedField Objects to 'lead'
-            $fieldObject     = false !== strpos($field->getObject(), 'extendedField') ? 'lead' : $field->getObject();
-            $isExtendedField = false !== strpos($field->getObject(), 'extendedField') ? true : false;
+            $fieldObject = false !== strpos($field->getObject(), 'extendedField') ? 'lead' : $field->getObject();
 
             if (in_array($type, ['lookup', 'multiselect', 'boolean'])) {
                 if ('boolean' == $type) {
                     //create a lookup list with ID
                     $properties['list'] = [
-                        0 => $properties['no'],
-                        1 => $properties['yes'],
+                        0 => isset($properties['no']) ? $properties['no'] : null,
+                        1 => isset($properties['yes']) ? $properties['yes'] : null,
                     ];
                 } else {
                     $properties['callback'] = 'activateLeadFieldTypeahead';


### PR DESCRIPTION
An exception will occur if a segment/filter results in a query across the same type of extended field twice.