### PR TITLE
[ENG-588] Use insert on duplicate key update.

### DIFF
--- a/Entity/ExtendedFieldRepositoryTrait.php
+++ b/Entity/ExtendedFieldRepositoryTrait.php
@@ -435,17 +435,16 @@ EOSQL;
                         $fieldValues[$id][$fields[$k]['group']][$fields[$k]['alias']]          = $fields[$k];
                         $fieldValues[$id][$fields[$k]['group']][$fields[$k]['alias']]['value'] = $r;
                     }
-
-                    // Alteration to core start.
-                    // Add the extended field to result if the current lead has that field value
-                    foreach ($extendedFieldList as $fieldToAdd => $e_config) {
-                        // @todo - Apply filters from extended fields
-                        $e_value                                                                                 = isset($extendedFieldValues[$id][$fieldToAdd]) ? $extendedFieldValues[$id][$fieldToAdd] : null;
-                        $fieldValues[$id][$fields[$fieldToAdd]['group']][$fields[$fieldToAdd]['alias']]          = $fields[$fieldToAdd];
-                        $fieldValues[$id][$fields[$fieldToAdd]['group']][$fields[$fieldToAdd]['alias']]['value'] = $e_value;
-                    }
-                    // Alteration to core end.
                 }
+
+                // Alteration to core start.
+                // Add the extended field to result if the current lead has that field value
+                foreach ($extendedFieldList as $fieldToAdd => $e_config) {
+                    $e_value                                                                                 = isset($extendedFieldValues[$id][$fieldToAdd]) ? $extendedFieldValues[$id][$fieldToAdd] : null;
+                    $fieldValues[$id][$fields[$fieldToAdd]['group']][$fields[$fieldToAdd]['alias']]          = $fields[$fieldToAdd];
+                    $fieldValues[$id][$fields[$fieldToAdd]['group']][$fields[$fieldToAdd]['alias']]['value'] = $e_value;
+                }
+                // Alteration to core end.
 
                 //make sure each group key is present
                 foreach ($groups as $g) {

--- a/Entity/ExtendedFieldRepositoryTrait.php
+++ b/Entity/ExtendedFieldRepositoryTrait.php
@@ -312,20 +312,18 @@ EOSQL;
             }
             // Handle inserts/updates in bulk by table.
             if ($insertUpdates) {
-                $values = $bindings = [];
                 foreach ($insertUpdates as $tableName => $leadField) {
+                    $rows = $params = [];
                     foreach ($leadField as $leadFieldId => $value) {
-                        $values[]                          = $leadId.', '.$leadFieldId.', :'.$tableName.$leadFieldId;
-                        $bindings[$tableName.$leadFieldId] = $value;
+                        $key          = $tableName.$leadFieldId;
+                        $rows[]       = $leadId.', '.$leadFieldId.', :'.$key;
+                        $params[$key] = $value;
                     }
-                    $sql  = 'INSERT INTO '.$tableName.' (lead_id, lead_field_id, value) '.
-                        'VALUES ('.implode('),(', $values).') '.
-                        'ON DUPLICATE KEY UPDATE value=VALUES(value);';
+                    $sql  = 'INSERT INTO '.$tableName.' (`lead_id`, `lead_field_id`, `value`) '.
+                        'VALUES ('.implode('),(', $rows).') '.
+                        'ON DUPLICATE KEY UPDATE `value`=VALUES(`value`);';
                     $stmt = $connection->prepare($sql);
-                    foreach ($bindings as $key => $value) {
-                        $stmt->bindParam($key, $value);
-                    }
-                    $stmt->execute();
+                    $stmt->execute($params);
                 }
             }
         }


### PR DESCRIPTION
This is necessary because the $changes array is not always trustable.
Enhancements validations, normalizations may occur causing the changes
array to not be indicative of the difference between what is in the
database and what is in memory. As a result, we are switching to an
insert on duplicate key update pattern, which will fail far less often
and ensure we are always persisting the most recent value.