### PR TITLE
[ENG-921] Fix regex delimiters

### DIFF
--- a/Entity/OverrideLeadRepository.php
+++ b/Entity/OverrideLeadRepository.php
@@ -391,7 +391,7 @@ class OverrideLeadRepository extends LeadRepository implements CustomFieldReposi
         $return = [];
 
         if (
-            (isset($filter->string) && preg_match('^\d{5}(?:[-\s]\d{4})?$', $filter->string))
+            (isset($filter->string) && preg_match('/^\d{5}(?:[-\s]\d{4})?$/', $filter->string))
             || false !== strpos(serialize($filter), 'zipcode')
         ) {
             $return = ['l.zipcode'];


### PR DESCRIPTION
preg_* functions require a full regular expression, including the wrapping delimiters. I'm not sure how or why PHP didn't reject `^' as a delimiter.